### PR TITLE
Update README.md usage example to wrap all routes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,14 @@ Import the package in your Dart code:
 import 'package:touch_indicator/touch_indicator.dart';
 ```
 
-Wrap your app in the `TouchIndicator` widget:
+Wrap all routes in your app in the `TouchIndicator` widget:
 
 ```dart
 class MyApp extends StatelessWidget {
   MaterialApp(
     title: 'Touch indicator example',
-    home: TouchIndicator(
-      child: MyHomePage(title: 'Flutter Demo Home Page'),
-    ),
+    builder: (context, child) => TouchIndicator(child: child),
+    home: MyHomePage(title: 'Flutter Demo Home Page'),
   );
 }
 ```


### PR DESCRIPTION
Wrapping only 'home' will show touches on the main route, but any Navigator.push() calls will
lose the touch indicators. Using the MaterialApp's 'builder' will wrap all routes, giving the desired behavior.